### PR TITLE
Fixes issue periods in names

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const flatten = require('flat')
 const FLATTEN_CONFIG = { delimiter: '-', maxDepth: 2 }
 const handleName = (name, className) => {
   const split = name.split(`${className}-`)
+  split[1] = split[1].replace('.', '\\.')
+
   const prefixedName = `${split[0]}${prefixNegativeModifiers(className, split[1])}`
 
   return prefixedName.split('-default').join('')


### PR DESCRIPTION
The css is messed up when the names contain periods, like:
```
'0.5': '0.125rem'
```
This will result in css like:
```
.-indent-0.\35{
  text-indent: -0.125rem;
}
```

After this fix it will correctly generate:
```
.-indent-\.5{
  text-indent: -0.125rem;
}
```